### PR TITLE
Allow compiling on macos

### DIFF
--- a/twib/twib/Twib.hpp
+++ b/twib/twib/Twib.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include<thread>
 #include<future>
 #include<mutex>


### PR DESCRIPTION
NOTE: You still need to use LLVM from homebrew. The macos clang is too old and doesn't support C++17.