### PR TITLE
build: Fix for Xcode clang not linking to asan

### DIFF
--- a/twib/CMakeLists.txt
+++ b/twib/CMakeLists.txt
@@ -12,7 +12,7 @@ endif()
 # enable ASAN
 if(NOT WIN32)
 	set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
-	set(CMAKE_LINKER_FLAGS_DEBUG "${CMAKE_STATIC_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
+	set(CMAKE_LINKER_FLAGS_DEBUG "${CMAKE_STATIC_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address -lasan")
 endif()
 
 set(MSGPACK11_BUILD_TESTS OFF CACHE BOOL "Build msgpack11 unit tests")


### PR DESCRIPTION
Not sure if you want to merge this or not, but when I tried to use Xcode for building twib, I had a bunch of linker errors. Adding this to the cmake file fixes it for me. (I could also wrap it in an `if generator = Xcode` or something).