### PR TITLE
gdb: Correctly support multiprocessing for reporting threads.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build/
 /.vs
 /twib/.vs
 /twib/CMakeSettings.json
+.vscode

--- a/twib/CMakeLists.txt
+++ b/twib/CMakeLists.txt
@@ -12,7 +12,7 @@ endif()
 # enable ASAN
 if(NOT WIN32)
 	set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
-	set(CMAKE_LINKER_FLAGS_DEBUG "${CMAKE_STATIC_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
+	set(CMAKE_LINKER_FLAGS_DEBUG "${CMAKE_STATIC_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address -lasan")
 endif()
 
 set(MSGPACK11_BUILD_TESTS OFF CACHE BOOL "Build msgpack11 unit tests")

--- a/twib/tool/GdbStub.cpp
+++ b/twib/tool/GdbStub.cpp
@@ -561,8 +561,14 @@ void GdbStub::QueryGetSupported(util::Buffer &packet) {
 			feature.push_back(ch);
 		}
 
+		if(feature == "multiprocess+") {
+			multiprocess_enabled = true;
+		}
+		
 		LogMessage(Debug, "gdb advertises feature: '%s'", feature.c_str());
 	}
+
+	LogMessage(Debug, "gdb multiprocess: %s", multiprocess_enabled ? "true" : "false");
 
 	bool is_first = true;
 	for(std::string &feature : features) {
@@ -570,10 +576,6 @@ void GdbStub::QueryGetSupported(util::Buffer &packet) {
 			response.Write(';');
 		} else {
 			is_first = false;
-		}
-
-		if(feature == "multiprocess+") {
-			multiprocess_enabled = true;
 		}
 		
 		response.Write(feature);

--- a/twib/tool/GdbStub.cpp
+++ b/twib/tool/GdbStub.cpp
@@ -402,8 +402,8 @@ void GdbStub::HandleVAttach(util::Buffer &packet) {
 		return;
 	}
 
-	if(!multi_process && attached_processes.size() > 0) {
-		LogMessage(Error, "Already debugging a process! Make sure multiprocessing is enabled!");
+	if(!multiprocess_enabled && attached_processes.size() > 0) {
+		LogMessage(Error, "Already debugging a process! Make sure multiprocess extensions are enabled!");
 		connection.RespondError(1);
 		return;
 	}
@@ -572,8 +572,8 @@ void GdbStub::QueryGetSupported(util::Buffer &packet) {
 			is_first = false;
 		}
 
-		if (feature == "multiprocess+") {
-			multi_process = true;
+		if(feature == "multiprocess+") {
+			multiprocess_enabled = true;
 		}
 		
 		response.Write(feature);
@@ -584,7 +584,7 @@ void GdbStub::QueryGetSupported(util::Buffer &packet) {
 
 void GdbStub::QueryGetCurrentThread(util::Buffer &packet) {
 	util::Buffer response;
-	if (multi_process) {
+	if(multiprocess_enabled) {
 		response.Write('p');
 		GdbConnection::Encode(current_thread ? current_thread->process.pid : 0, 0, response);
 		response.Write('.');
@@ -622,7 +622,7 @@ void GdbStub::QueryGetSThreadInfo(util::Buffer &packet) {
 			} else {
 				response.Write('m');
 			}
-			if (multi_process) {
+			if(multiprocess_enabled) {
 				response.Write('p');
 				GdbConnection::Encode(thread.process.pid, 0, response);
 				response.Write('.');

--- a/twib/tool/GdbStub.hpp
+++ b/twib/tool/GdbStub.hpp
@@ -106,6 +106,7 @@ class GdbStub {
 	std::string stop_reason = "W00";
 	bool waiting_for_stop = false;
 	bool has_async_wait = false;
+	bool multi_process = false;
 
 	void Stop();
 	

--- a/twib/tool/GdbStub.hpp
+++ b/twib/tool/GdbStub.hpp
@@ -106,7 +106,7 @@ class GdbStub {
 	std::string stop_reason = "W00";
 	bool waiting_for_stop = false;
 	bool has_async_wait = false;
-	bool multi_process = false;
+	bool multiprocess_enabled = false;
 
 	void Stop();
 	


### PR DESCRIPTION
I came across this while trying to use the gdb stub with ida and ida did not list any threads because it did not recognize the format the threads where reported in. This checks whether the `Supported` query contains `multiprocess+` and only then also sends the process id along with the thread id. It also errors if you try to attach to more than one process without multi process being enabled.

Btw. not sure if the `+` after `multiprocess` get's stripped or not.