### PR TITLE
Fix 'ENN' error reporting when the error code is not in the range 0-9.

### DIFF
--- a/twib/tool/GdbConnection.cpp
+++ b/twib/tool/GdbConnection.cpp
@@ -140,12 +140,11 @@ void GdbConnection::RespondEmpty() {
 }
 
 void GdbConnection::RespondError(int no) {
-	util::Buffer ok;
-	ok.Write('E');
-	// this is really bad
-	ok.Write('0');
-	ok.Write('0' + no);
-	Respond(ok);
+	util::Buffer buf;
+	char resp[4];
+	snprintf(resp, sizeof(resp), "E%02x", no & 0xff);
+	buf.Write((const char *)resp);
+	Respond(buf);
 }
 
 void GdbConnection::RespondOk() {


### PR DESCRIPTION
GDB limits the code to two hex digits, so it will be truncated if it's
too high.  In the future it would be nice to change the parameter to
uint8_t or something; for now, some callers pass a Result code as the
error code...