### PR TITLE
Support reading and writing FPU registers.

### DIFF
--- a/twib/tool/GdbStub.hpp
+++ b/twib/tool/GdbStub.hpp
@@ -74,8 +74,8 @@ class GdbStub {
 	class Thread {
 	 public:
 		Thread(Process &process, uint64_t thread_id, uint64_t tls_addr);
-		std::vector<uint64_t> GetRegisters();
-		void SetRegisters(std::vector<uint64_t> regs);
+		ThreadContext GetRegisters();
+		void SetRegisters(const ThreadContext &regs);
 		Process &process;
 		uint64_t thread_id = 0;
 		uint64_t tls_addr = 0;

--- a/twib/tool/interfaces/ITwibDebugger.cpp
+++ b/twib/tool/interfaces/ITwibDebugger.cpp
@@ -75,26 +75,20 @@ std::optional<nx::DebugEvent> ITwibDebugger::GetDebugEvent() {
 	return event;
 }
 
-std::vector<uint64_t> ITwibDebugger::GetThreadContext(uint64_t thread_id) {
-	struct ThreadContext {
-		uint64_t regs[100];
-	} tc;
+ThreadContext ITwibDebugger::GetThreadContext(uint64_t thread_id) {
+	ThreadContext tc;
 	obj->SendSmartSyncRequest(
 		CommandID::GET_THREAD_CONTEXT,
 		in<uint64_t>(thread_id),
 		out<ThreadContext>(tc));
-	return std::vector<uint64_t>(&tc.regs[0], &tc.regs[100]);
+	return tc;
 }
 
-void ITwibDebugger::SetThreadContext(uint64_t thread_id, std::vector<uint64_t> regs) {
-	struct ThreadContext {
-		uint64_t regs[100];
-	} tc;
-	std::copy(regs.begin(), regs.end(), tc.regs);
+void ITwibDebugger::SetThreadContext(uint64_t thread_id, ThreadContext tc) {
 	obj->SendSmartSyncRequest(
 		CommandID::SET_THREAD_CONTEXT,
 		in<uint64_t>(thread_id),
-		in<uint32_t>(3), // gprs + pc + sp + cpsr
+		in<uint32_t>(15), // gprs + pc + sp + cpsr + fpu + fpcr/fpsr
 		in<ThreadContext>(tc));
 }
 

--- a/twib/tool/interfaces/ITwibDebugger.hpp
+++ b/twib/tool/interfaces/ITwibDebugger.hpp
@@ -31,6 +31,17 @@ namespace twili {
 namespace twib {
 namespace tool {
 
+struct ThreadContext {
+     uint64_t x[31];
+     uint64_t sp, pc;
+     uint32_t psr;
+     uint32_t _pad;
+     uint64_t fpr[32][2];
+     uint32_t fpcr, fpsr;
+     uint64_t tpidr;
+};
+static_assert(sizeof(ThreadContext) == 800, "sizeof(ThreadContext)");
+
 class ITwibDebugger {
  public:
 	ITwibDebugger(std::shared_ptr<RemoteObject> obj);
@@ -41,8 +52,8 @@ class ITwibDebugger {
 	std::vector<uint8_t> ReadMemory(uint64_t addr, uint64_t size);
 	void WriteMemory(uint64_t addr, std::vector<uint8_t> &bytes);
 	std::optional<nx::DebugEvent> GetDebugEvent();
-	std::vector<uint64_t> GetThreadContext(uint64_t thread_id);
-	void SetThreadContext(uint64_t thread_id, std::vector<uint64_t> registeres);
+	ThreadContext GetThreadContext(uint64_t thread_id);
+	void SetThreadContext(uint64_t thread_id, ThreadContext tc);
 	void ContinueDebugEvent(uint32_t flags, std::vector<uint64_t> thread_ids);
 	void BreakProcess();
 	void AsyncWait(std::function<void(uint32_t)> &&cb);


### PR DESCRIPTION
And refactor `Get`/`SetThreadContext` in twib to use `ThreadContext` (which unfortunately has to be redefined there) instead of `std::vector<uint64_t>`; it makes it more clear what the memcpys are doing.
    
Note: This depends on [this libtransistor PR](https://github.com/misson20000/libtransistor/pull/2).

