### PR TITLE
bridge: Don't error out when sending a 0-byte response.

### DIFF
--- a/twili/bridge/tcp/ResponseState.cpp
+++ b/twili/bridge/tcp/ResponseState.cpp
@@ -78,7 +78,7 @@ void TCPBridge::Connection::ResponseState::InsertObject(std::pair<uint32_t, std:
 }
 
 void TCPBridge::Connection::ResponseState::Send(uint8_t *data, size_t size) {
-	do {
+	while(size > 0) {
 		ssize_t r = bsd_send(connection->socket.fd, data, size, 0);
 		if(r <= 0) {
 			connection->deletion_flag = true;
@@ -86,7 +86,7 @@ void TCPBridge::Connection::ResponseState::Send(uint8_t *data, size_t size) {
 		}
 		size-= r;
 		data+= r;
-	} while(size > 0);
+	}
 }
 
 } // namespace tcp

--- a/twili/bridge/usb/ResponseState.cpp
+++ b/twili/bridge/usb/ResponseState.cpp
@@ -55,6 +55,9 @@ void USBBridge::ResponseState::SendHeader(protocol::MessageHeader &hdr) {
 }
 
 void USBBridge::ResponseState::SendData(uint8_t *data, size_t size) {
+	if(size == 0) {
+		return;
+	}
 	auto max_size = bridge.response_data_buffer.size;
 	while(size > max_size) {
 		SendData(data, max_size);


### PR DESCRIPTION
Both the USB and TCP bridge had issues in this case.  For USB, it would
try to send a 0-byte USB packet but the USB stack would return an error.
For TCP, it seems like bsd_send would return 0 and twili would then
interpret that as an error (haven't actually tested this).