### PR TITLE
Add NcmStorageId "none" to understood locations 

### DIFF
--- a/common/util.hpp
+++ b/common/util.hpp
@@ -20,6 +20,7 @@
 
 #include<optional>
 #include<vector>
+#include<stdint.h>
 
 namespace twili {
 namespace util {

--- a/twib/tool/Twib.cpp
+++ b/twib/tool/Twib.cpp
@@ -563,7 +563,7 @@ int main(int argc, char *argv[]) {
 	std::string launch_storage;
 	uint32_t launch_flags = 0;
 	launch->add_option("title-id", launch_title_id, "Title ID to launch")->required();
-	launch->add_set_ignore_case("storage", launch_storage, {"host", "gamecard", "gc", "nand-system", "system", "nand-user", "user", "sdcard", "sd"}, "Storage for title")->required();
+	launch->add_set_ignore_case("storage", launch_storage, {"none", "host", "gamecard", "gc", "nand-system", "system", "nand-user", "user", "sdcard", "sd"}, "Storage for title")->required();
 	launch->add_option("launch-flags", launch_flags, "Flags for launch");
 
 	FSCommands sd_commands(app, "sd", "Perform operations on target SD card", "sd");


### PR DESCRIPTION
Previously the CLI lib returned "The value none is not an allowed value for storage", even though twib had code for it. The missing header fixes compilation on my machine.